### PR TITLE
Add GitHub URLs

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -7,6 +7,8 @@ Authors@R: person("Eric", "Persson", email = "expersso5@gmail.com", role = c("au
 Description: Provides programmatic access to the GESIS - Leibniz-Institute for
     the Social Sciences Data Catalogue/Datenbestandkatalog (DBK), which
     maintains a large repository of data sets related to the social sciences.
+URL: https://github.com/expersso/gesis
+BugReports: https://github.com/expersso/gesis/issues
 License: CC0
 LazyData: TRUE
 Suggests:


### PR DESCRIPTION
Hi! I found this on https://cran.r-project.org/web/packages/available_packages_by_date.html and guess this is the source ;-) How about noting that URLs in `DESCRIPTION`?

Thank you, esp. for publishing this plugin! Good to see another client for a research data repository.