### PR TITLE
Fix #12 issue with 3-digit GESIS identifiers

### DIFF
--- a/R/gesis.R
+++ b/R/gesis.R
@@ -65,6 +65,10 @@ login <- function(username = "", password = "") {
 #' download_dataset(s, doi = "0078")}
 download_dataset <- function(s, doi, path = ".", filetype = ".dta",
                              purpose = 1, quiet = FALSE) {
+
+    # add trailing 0 if GESIS identifier is of the form '990'
+    doi <- ifelse(nchar(doi) == 3, paste0("0", doi), as.character(doi))
+
     for(d in doi) {
 
         url <- paste0("https://dbk.gesis.org/dbksearch/SDesc2.asp?db=E&no=", d)

--- a/R/gesis.R
+++ b/R/gesis.R
@@ -34,7 +34,9 @@ login <- function(username = "", password = "") {
 #' Download a Gesis data set
 #'
 #' @param s A session object created with login()
-#' @param doi The unique identifier(s) for the data set(s)
+#' @param doi The unique identifier(s) for the data set(s), which might be its
+#' Digital Object Identifier (DOI), as in '10.4232/1.12959', or its GESIS/ZACAT
+#' identifier, as in '6925'.
 #' @param path Directory to which to download the file
 #' @param filetype The filetype to download (usually available: .dta/.por/.sav)
 #' @param purpose The purpose for downloading the data. See details.
@@ -93,7 +95,9 @@ download_dataset <- function(s, doi, path = ".", filetype = ".dta",
 
 #' Download the codebook for a Gesis data set
 #'
-#' @param doi The unique identifier(s) for the data set(s)
+#' @param doi The unique identifier(s) for the data set(s), which might be its
+#' Digital Object Identifier (DOI), as in '10.4232/1.12959', or its GESIS/ZACAT
+#' identifier, as in '6925'.
 #' @param path Directory to which to download the file
 #' @param quiet Whether to output download message.
 #'
@@ -200,7 +204,7 @@ get_gesis_id <- function(x, quiet = FALSE) {
     }
 
     # if GESIS identifier is of the form '990',
-    # add trailing 0 brefore returning
+    # add trailing 0 before returning
     ifelse(nchar(x) == 3, paste0("0", x), x)
 
 }


### PR DESCRIPTION
This PR does two things:

1. If `doi` is an actual DOI instead of a GESIS identifier, it converts it to a GESIS identifier.
2. If the GESIS identifier lacks a trailing zero, it adds it.

The PR adds a new internal function, `get_gesis_id`, to do so. It uses `httr`, which is already imported by the package, and is otherwise coded in base R in order to avoid adding dependencies.

I refrained from adding any additional checks on `doi`, although GESIS identifiers are, it seems, always made of four digits, so that could also get checked at some point.

I also refrained from changing the rest of the codes, including the messages, that call GESIS identifiers "DOI", in order not to disrupt the discussion in #12 about this.